### PR TITLE
Update nanobind to 2.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core >=0.10",
-    "nanobind >=2.8.0"
+    "nanobind >=2.9.2"
 ]
 build-backend = "scikit_build_core.build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ sdist.exclude = [ ".*" ]
 # Necessary to see build output from the actual compilation
 build-verbosity = 1
 
-# Skip builds with Python 3.14t on macOS
-skip = "cp314t-macosx_*"
-
 # Run tests to ensure that the package was correctly built
 test-command = "python -m unittest discover -s {project}/tests"
 


### PR DESCRIPTION
This resolves the undefined symbol errors that occurred when building for Python 3.14t on macOS.